### PR TITLE
Add .travis.yml to fix Travis build. See comment on #1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.12"


### PR DESCRIPTION
The Travis build seemed to be failing because it was trying to run rake as though this were a Ruby project - perhaps due to missing `.travis.yml`.

See [my comment](https://github.com/jonschlinkert/list-item/pull/1#issuecomment-118447064) on #1.
